### PR TITLE
Rename Edit button to Save

### DIFF
--- a/config/locales/interests/en.yml
+++ b/config/locales/interests/en.yml
@@ -31,7 +31,7 @@
 
 en:
   interests:
-    add_button: "Edit"
+    add_button: "Save"
     title: "Edit interests"
     description_html: "Write a list of your interests in English, separated by commas (this \",\").<br/> Please try to order them by order of preference, meaning the most important first!"
     interests_picking: "Want to discover new interests? Here are some recently added by other members:"

--- a/config/locales/interests/fr.yml
+++ b/config/locales/interests/fr.yml
@@ -31,7 +31,7 @@
 
 fr:
   interests:
-    add_button: "Éditer"
+    add_button: "Sauvegarder"
     title: "Éditez vos centres d'intérêts"
     description_html: "Écrivez une liste de vos centres d'intérêts en anglais, séparés par des virgules (ceci \",\").<br/> Ordonnez par ordre de préférence, c'est-à-dire le plus important en premier !"
     interests_picking: "Vous voulez découvrir de nouveux centres d'intérêts ? Voici une liste de quelques uns récemment ajoutés par d'autres membres :"


### PR DESCRIPTION
## Description
- Rename "Edit" button to "Save"

## Reason
Make button more explicit about its action.
Closes #31 